### PR TITLE
Add Travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - "2.7"
+script: make lint test
+notifications:
+  email: false

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ mockldap==0.2.0  # Required for mock_ldap_helpers
 nose==1.3.6
 pep8==1.5.7
 pyflakes==0.8.1
-ipdb


### PR DESCRIPTION
@jdavisp3 @jtratner This PR adds travis-ci.org integration to `baya`.  I'd also planned to add Python3 compatibility, but `python-ldap` is apparently not yet Python 3 compatible.  The build passes, as you'd hope: https://travis-ci.org/counsyl/baya/builds/123216111
