### PR TITLE
Update test setup to try and get lint & python 3 working.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 install:
   - pip install tox tox-travis
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 install_command = pip install {opts} {packages}
 downloadcache = {toxworkdir}/_download/
-envlist = lint,{py27,py35}-{1.8,1.9,1.10}
+envlist = {py27,py35}-{lint,1.8,1.9,1.10}
 indexserver =
     default = https://pypi.python.org/simple
 
@@ -9,8 +9,7 @@ indexserver =
 usedevelop = True
 commands =
   coverage run -p --omit="*tests*" --source=baya --branch \
-    ./baya/tests/manage.py test {posargs:baya} \
-    --with-xunit --xunit-file=nosetests-{envname}.xml
+    ./baya/tests/manage.py test {posargs:baya}
 deps =
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
Test-only changes to try getting the travis build running on the lint and python 3 environments, that were getting ignored before.