### PR TITLE
Make repo pipeline compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,84 @@
+PACKAGE_NAME?=baya
+VENV_DIR?=.venv
+VENV_ACTIVATE=$(VENV_DIR)/bin/activate
+WITH_VENV=. $(VENV_ACTIVATE);
+TEST_OUTPUT?=nosetests.xml
+
+ifdef TOX_ENV
+	TOX_ENV_FLAG := -e $(TOX_ENV)
+else
+	TOX_ENV_FLAG :=
+endif
+
+.PHONY: default
+default:
+	python setup.py check build
+
+.PHONY: venv
+venv: $(VENV_ACTIVATE)
+
+$(VENV_ACTIVATE): requirements*.txt
+	test -f $@ || virtualenv --python=python2.7 $(VENV_DIR)
+	$(WITH_VENV) pip install --no-deps -r requirements-setup.txt
+	$(WITH_VENV) pip install --no-deps -r requirements.txt
+	$(WITH_VENV) pip install --no-deps -r requirements-dev.txt
+
+develop: venv
+	$(WITH_VENV) python setup.py develop
+
+.PHONY: setup
+setup: venv
+
+.PHONY: clean
+clean:
+	python setup.py clean
+	rm -rf build/
+	rm -rf dist/
+	rm -rf *.egg*/
+	rm -rf __pycache__/
+	rm -f MANIFEST
+	rm -f $(TEST_OUTPUT)
+	find $(PACKAGE_NAME) -type f -name '*.pyc' -delete
+
+.PHONY: teardown
+teardown:
+	rm -rf .tox $(VENV_DIR)/
+
+.PHONY: lint
+lint: venv
+	$(WITH_VENV) flake8 -v $(PACKAGE_NAME)/
+
+.PHONY: test
+test: venv
+	$(WITH_VENV) \
+	coverage erase ; \
+	tox -v $(TOX_ENV_FLAG); \
+	status=$$?; \
+	coverage combine; \
+	coverage html --directory=coverage --omit="tests*"; \
+	coverage report; \
+	xunitmerge nosetests-*.xml $(TEST_OUTPUT); \
+	exit $$status;
+
+# Distribution
+VERSION=`$(WITH_VENV) python setup.py --version`
+
+.PHONY: version
+version: venv
+version:
+	@echo ${VERSION}
+
+.PHONY: tag
+tag: ##[distribution] Tag the release.
+tag: venv
+	echo "Tagging version as ${VERSION}"
+	git tag -a ${VERSION} -m 'Version ${VERSION}'
+	# We won't push changes or tags here allowing the pipeline to do that, so we don't accidentally do that locally.
+
+.PHONY: dist
+dist: venv
+	$(WITH_VENV) python setup.py sdist
+
+.PHONY: sdist
+sdist: dist
+	@echo "runs dist"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,6 @@ django-nose==1.4.4
 mock==1.0.1
 mockldap==0.2.6  # Required for mock_ldap_helpers
 nose==1.3.6
+pep8==1.7.1  # Required for flake8
+pyflakes==1.6.0  # Required for flake8
+flake8==2.4.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 install_command = pip install {opts} {packages}
 downloadcache = {toxworkdir}/_download/
-envlist = {py27,py35}-{lint,1.8,1.9,1.10}
+envlist = {py27,py35}-{1.8,1.9,1.10}
 indexserver =
     default = https://pypi.python.org/simple
 
@@ -16,12 +16,6 @@ deps =
   1.8: Django>=1.8,<1.9
   1.9: Django>=1.9,<1.10
   1.10: Django>=1.10,<1.11
-
-[testenv:lint]
-commands =
-  flake8 -v baya
-deps =
-  flake8==2.4.1
 
 [flake8]
 ignore = E731,E402


### PR DESCRIPTION
@lucaswiman cc @jdavisp3 

This PR makes this library compatible with our internal publishing mechanisms. I tested this branch with said mechanisms and confirmed that the 1.0.1 version was [published to pypi](https://pypi.python.org/pypi/baya).