### PR TITLE
Run lint as part of travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
   - pip install tox tox-travis
 script:
+  - make lint
   - tox
 notifications:
   email: false


### PR DESCRIPTION
@jdavisp3 @lucaswiman 

I introduced a linter error in https://github.com/counsyl/baya/pull/17 which @jdavisp3 fixed in https://github.com/counsyl/baya/pull/18. This PR updates the travis config to add a lint step to the build so that linting issues can be surfaced on PRs and not when we go to publish new package versions.