### PR TITLE
Fix build and pypi upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,6 @@ test: venv
 	coverage erase ; \
 	tox -v $(TOX_ENV_FLAG); \
 	status=$$?; \
-	coverage combine; \
-	coverage html --directory=coverage --omit="tests*"; \
 	coverage report; \
 	exit $$status;
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ PACKAGE_NAME?=baya
 VENV_DIR?=.venv
 VENV_ACTIVATE=$(VENV_DIR)/bin/activate
 WITH_VENV=. $(VENV_ACTIVATE);
-TEST_OUTPUT?=nosetests.xml
 
 ifdef TRAVIS_PYTHON_VERSION
     PYTHON=python$(TRAVIS_PYTHON_VERSION)
@@ -43,7 +42,6 @@ clean:
 	rm -rf *.egg*/
 	rm -rf __pycache__/
 	rm -f MANIFEST
-	rm -f $(TEST_OUTPUT)
 	find $(PACKAGE_NAME) -type f -name '*.pyc' -delete
 
 .PHONY: teardown
@@ -63,7 +61,6 @@ test: venv
 	coverage combine; \
 	coverage html --directory=coverage --omit="tests*"; \
 	coverage report; \
-	xunitmerge nosetests-*.xml $(TEST_OUTPUT); \
 	exit $$status;
 
 # Distribution

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-coverage==3.7.1
+coverage==5.1
 django-nose==1.4.6
 mock==1.0.1
 mockldap==0.2.6  # Required for mock_ldap_helpers

--- a/requirements-setup.txt
+++ b/requirements-setup.txt
@@ -5,6 +5,5 @@ Django>=1.11
 pluggy==0.3.0
 py==1.4.27
 tox==2.0.1
-tox-pyenv==1.1.0
 virtualenv==16.7.4
 xunitmerge==1.0.4

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ indexserver =
 [testenv]
 usedevelop = True
 commands =
-  coverage run -p --omit="*tests*" --source=baya --branch \
+  coverage run --omit="*tests*" --source=baya --branch \
     ./baya/tests/manage.py test {posargs:baya}
 deps =
   -r{toxinidir}/requirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 install_command = pip install {opts} {packages}
 downloadcache = {toxworkdir}/_download/
-envlist = {py36,py37}-{1.11,2.0,2.1,2.2}
+envlist = {py36}-{1.11,2.0,2.1,2.2}
 indexserver =
     default = https://pypi.python.org/simple
 


### PR DESCRIPTION
@counsyl-opensource 

There have been lots of changes to Baya over the last year, but the build and PyPI-upload pipeline has been stalled due to errors, mostly due to asking for `pyenv` or Python 3.7, which are not available 

I need some of these changes to silence some errors in Website, and we'll also need these changes for the Django 2 upgrade, so I'd like to try to get this pipeline unstuck.

# How Tested

Test pass locally for me, and I've removed all of the objectionable lines for GoCD, but I think I'll have to merge and monitor the upload pipeline before finally judging whether these fixes are successful.