### PR TITLE
Remove Django 2.2 target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 install_command = pip install {opts} {packages}
 downloadcache = {toxworkdir}/_download/
-envlist = {py36}-{1.11,2.0,2.1,2.2}
+envlist = {py36}-{1.11,2.0,2.1}
 indexserver =
     default = https://pypi.python.org/simple
 
@@ -15,7 +15,6 @@ deps =
   1.11: Django>=1.11,<2.0
   2.0: Django>=2.0,<2.1
   2.1: Django>=2.1,<2.2
-  2.2: Django>=2.2,<2.3
 
 [flake8]
 ignore = E731,E402


### PR DESCRIPTION
The Django 2.2 target needs a version of sqlite that's not available on GoCD.  Let me remove this target to get the builder unstuck.