### PR TITLE
Demote versions to more realistic numbers and fix `lint` and `test`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 coverage==5.1
 django-nose==1.4.6
 mock==1.0.1
-mockldap==0.2.6  # Required for mock_ldap_helpers
+mockldap==0.2.6
 nose==1.3.7
-pyflakes==2.1.1  # Required for flake8
-flake8==3.7.7
+pycodestyle==2.0.0
+pyflakes==0.9
+flake8==2.6.2


### PR DESCRIPTION
CC @counsyl-opensource 

Follow-on to https://github.com/counsyl/baya/pull/27 that demotes the development and testing libraries I had automatically jacked to their most recent versions to the highest minor versions already used in the repo's current version.  I did this because to express the dependency closure of that modern version of `flake8` in our requirements files here would be too much trouble.

This change fixes the breakage we currently have in the `lint` stage of our deploy pipeline because modern `flake8` requires package `entrypoints`.  Now, it doesnt'.