### PR TITLE
add supported versions of python and django

### DIFF
--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -1,0 +1,28 @@
+name: Test pull request
+on: pull_request
+jobs:
+  tox:
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python: ['3.6', '3.8', '3.9', '3.10']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e py
+  lint:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - run: make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
 install:
   - pip install tox tox-travis
 script:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ WITH_VENV=. $(VENV_ACTIVATE);
 ifdef TRAVIS_PYTHON_VERSION
     PYTHON=python$(TRAVIS_PYTHON_VERSION)
 else
-    PYTHON=python3.6
+    PYTHON=python3.9
 endif
 
 ifdef TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 install_command = pip install {opts} {packages}
 downloadcache = {toxworkdir}/_download/
-envlist = {py36}-{1.11,2.0,2.1}
+envlist = {py37,py38,py39}-{2.2,3.0,3.1,3.2,4.0}
 indexserver =
     default = https://pypi.python.org/simple
 
@@ -12,9 +12,13 @@ commands =
     ./baya/tests/manage.py test {posargs:baya}
 deps =
   -r{toxinidir}/requirements-dev.txt
-  1.11: Django>=1.11,<2.0
   2.0: Django>=2.0,<2.1
   2.1: Django>=2.1,<2.2
+  2.2: Django>=2.2,<3.0
+  3.0: Django>=3.0,<3.1
+  3.1: Django>=3.1,<3.2
+  3.2: Django>=2.2,<4.0
+  4.0: Django>=4.0,<4.1
 
 [flake8]
 ignore = E731,E402


### PR DESCRIPTION
Adding more tox options to test newer and wider set of python and django version

## changes

- adds tests: 
    - python 3.8, 3.9
    - django: 3.1, 3.2, 4.0
- drops tests:
    - python 3.6
    - django 1.11
    
# How tested
- changes are tox config, tested with unittests!
