### PR TITLE
Update mock

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-2.1.0: Add support for django 4.0, 4.1. Add support for Python 3.10, 3.11.
+2.1.0: Add support for django 4.0, 4.1. Add support for Python 3.10, 3.11, 3.12
 2.0.3: remove upper bound on django requirement
 2.0.2: Bump py, flake8 and other dependencies for security.
 2.0.0: Support for django 2.0, 2.1, 2.2. Add support for Python3.7. Drop support for Python 2.7

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ default:
 venv: $(VENV_ACTIVATE)
 
 $(VENV_ACTIVATE): requirements*.txt setup.py
-	test -f $@ || virtualenv --python=$(PYTHON) $(VENV_DIR)
+	test -f $@ || python3 -m venv $(VENV_DIR) || virtualenv --python=$(PYTHON) $(VENV_DIR)
 	$(WITH_VENV) pip install --no-deps -r requirements-setup.txt
 	$(WITH_VENV) pip install -e .
 	$(WITH_VENV) pip install --no-deps -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ default:
 venv: $(VENV_ACTIVATE)
 
 $(VENV_ACTIVATE): requirements*.txt setup.py
+	pip install virtualenv==20.8.1
 	test -f $@ || python3 -m venv $(VENV_DIR) || virtualenv --python=$(PYTHON) $(VENV_DIR)
 	$(WITH_VENV) pip install --no-deps -r requirements-setup.txt
 	$(WITH_VENV) pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ WITH_VENV=. $(VENV_ACTIVATE);
 ifdef TRAVIS_PYTHON_VERSION
     PYTHON=python$(TRAVIS_PYTHON_VERSION)
 else
-    PYTHON=python3.9
+    PYTHON=python3.10
 endif
 
 ifdef TOX_ENV
@@ -84,3 +84,25 @@ dist: venv
 .PHONY: sdist
 sdist: dist
 	@echo "runs dist"
+
+### Infastructure for Github Actions
+.PHONY: ci-libs
+ci-libs:
+	sudo apt-get update -y
+	sudo apt-get install -y libldap2-dev libssl-dev libsasl2-dev
+
+.PHONY: ci-install
+ci-install: ci-libs venv
+
+.PHONY: ci-lint
+ci-lint: lint
+
+.PHONY: ci-test
+ci-test: test
+
+.PHONY: ci-version
+ci-version: version
+
+.PHONY: ci-publish
+ci-publish:
+	$(WITH_VENV) python setup.py sdist

--- a/baya/backend.py
+++ b/baya/backend.py
@@ -1,5 +1,4 @@
 from functools import partial
-import six
 
 from django.conf import settings
 from django.contrib.auth import get_permission_codename
@@ -34,7 +33,7 @@ class NestedLDAPGroupsBackend(LDAPBackend):
             user, obj)
         from baya.admin.sites import _admin_registry
         for admin_site in _admin_registry:
-            for model, opts in six.iteritems(admin_site._registry):
+            for model, opts in admin_site._registry.items():
                 app = model._meta.app_label
                 perm_name = partial(get_permission_codename, opts=model._meta)
                 if (hasattr(opts, 'user_has_add_permission') and

--- a/baya/mock_ldap_helpers.py
+++ b/baya/mock_ldap_helpers.py
@@ -149,8 +149,8 @@ def mock_ldap_setup(
     `.start()` on the returned value.
     """
     from django.conf import settings
-    import mock
     import mockldap
+    from unittest import mock
 
     class MockLDAP(mockldap.MockLdap):
         def start(self, *args, **kwargs):

--- a/baya/permissions.py
+++ b/baya/permissions.py
@@ -16,7 +16,6 @@ if django.VERSION[0] == 1:
 elif django.VERSION[0] >= 2:
     from django.urls.resolvers import URLPattern
     from django.urls.resolvers import URLResolver
-import six
 
 from .membership import BaseNode
 from .membership import ValueNode
@@ -87,7 +86,7 @@ class Gate(object):
 
         if groups is None:
             groups = []
-        elif isinstance(groups, six.string_types):
+        elif isinstance(groups, str):
             groups = [group.strip() for group in groups.split(',')]
 
         return self.DEFAULT_PERMISSION_NODE(*groups)
@@ -184,10 +183,10 @@ class Gate(object):
         self.get_requires &= other.get_requires
         self.post_requires &= other.post_requires
         # Prefer other's login_url, if set
-        login_text_type = six.text_type(settings.BAYA_LOGIN_URL)
+        login_text_type = str(settings.BAYA_LOGIN_URL)
         if (
             other.login_url is not None and
-            six.text_type(other.login_url) != login_text_type
+            str(other.login_url) != login_text_type
         ):
             self.login_url = other.login_url
         return self
@@ -374,7 +373,7 @@ class requires(object):
                 raise TypeError("Cannot decorate Inlines. See "
                                 "baya.admin.options.BayaInline instead.")
             return self.decorate_admin(fn, *args, **kwargs)
-        elif isinstance(fn, six.string_types):
+        elif isinstance(fn, str):
             raise TypeError("Cannot decorate string-path to view: %s." % fn)
         else:
             # You'll probably only get here if you're trying to decorate

--- a/baya/permissions.py
+++ b/baya/permissions.py
@@ -1,9 +1,10 @@
-import collections
 import functools
-import sys
 
-if sys.version_info[:2] >= (3, 10):
-    collections.Callable = collections.abc.Callable
+try:
+    from collections.abc import Callable
+except:
+    from collections import Callable
+
 
 import django
 from django.conf import settings
@@ -361,7 +362,7 @@ class requires(object):
                 'Cannot decorate a bare functools.partial view.  '
                 'You must invoke functools.update_wrapper(partial_view, '
                 'full_view) first.')
-        if not isinstance(fn, type) and isinstance(fn, collections.Callable):
+        if not isinstance(fn, type) and isinstance(fn, Callable):
             return self.decorate_method(fn, *args, **kwargs)
         elif isinstance(fn, tuple):
             # Must be an include('my_app.urls') we're decorating

--- a/baya/permissions.py
+++ b/baya/permissions.py
@@ -2,7 +2,7 @@ import functools
 
 try:
     from collections.abc import Callable
-except:
+except Exception:
     from collections import Callable
 
 

--- a/baya/tests/settings.py
+++ b/baya/tests/settings.py
@@ -21,7 +21,6 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.sessions',
     'django.contrib.contenttypes',
-    'django_nose',
     'baya',
     'baya.tests',
     'baya.tests.submod',
@@ -82,8 +81,6 @@ STATIC_FILE_FINDERS = (
 
 STATIC_URL = '/static/'
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
 CSRF_USE_SESSIONS = False
 
 MIDDLEWARE = (
@@ -129,3 +126,5 @@ AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
     ldap.SCOPE_SUBTREE,
     "(objectClass=groupOfNames)"
 )
+
+USE_TZ = False

--- a/baya/tests/test_admin.py
+++ b/baya/tests/test_admin.py
@@ -1,4 +1,3 @@
-import six
 from django.contrib.admin.options import InlineModelAdmin
 
 from baya import RolesNode as g
@@ -12,8 +11,8 @@ from baya.tests.models import Blag
 from baya.tests.models import BlagEntry
 from baya.tests.submod.models import Comment
 from baya.tests.test_base import LDAPGroupAuthTestBase
-import mock
-from mock import MagicMock
+from unittest import mock
+from unittest.mock import MagicMock
 
 
 class TestAdminSite(LDAPGroupAuthTestBase):
@@ -62,7 +61,7 @@ class TestAdminSite(LDAPGroupAuthTestBase):
         app_list = index.context_data['app_list']
         self.assertEqual(len(app_list), 2)
         for app in app_list:
-            models = {six.text_type(model['name']) for model in app['models']}
+            models = {str(model['name']) for model in app['models']}
             if len(models) == 2:
                 self.assertEqual({"Blags", "Entries"}, models)
                 for model in app['models']:
@@ -84,7 +83,7 @@ class TestAdminSite(LDAPGroupAuthTestBase):
         app_list = app_list[0]
         self.assertEqual(
             {"Blags"},
-            {six.text_type(model['name']) for model in app_list['models']})
+            {str(model['name']) for model in app_list['models']})
         perms = app_list['models'][0]['perms']
         self.assertFalse(perms['add'])
         self.assertTrue(perms['change'])

--- a/baya/tests/test_backend.py
+++ b/baya/tests/test_backend.py
@@ -1,7 +1,7 @@
 import ldap
 from django.test import TestCase
-from mock import Mock
-from mock import sentinel
+from unittest.mock import Mock
+from unittest.mock import sentinel
 
 from baya.backend import NestedLDAPGroupsBackend
 from baya.backend import ReconnectingLDAP

--- a/baya/tests/test_backend.py
+++ b/baya/tests/test_backend.py
@@ -12,7 +12,7 @@ class TestReconnectingLDAP(TestCase):
     def test_getattr_not_initialize(self):
         ldap = Mock()
         reconnecting_ldap = ReconnectingLDAP(ldap)
-        self.assertIs(reconnecting_ldap.not_initialize, ldap.not_initialize)
+        assert reconnecting_ldap.not_initialize is ldap.not_initialize
 
     def test_initialize(self):
         ldap = Mock()
@@ -30,8 +30,8 @@ class TestReconnectingLDAPBackend(TestCase):
     def test_reconnecting_backend(self):
         backend = self.TestBackend()
         ldap_module = backend.ldap
-        self.assertTrue(isinstance(ldap_module, ReconnectingLDAP))
-        self.assertIs(ldap_module.SERVER_DOWN, ldap.SERVER_DOWN)
+        assert isinstance(ldap_module, ReconnectingLDAP)
+        assert ldap_module.SERVER_DOWN is ldap.SERVER_DOWN
 
 
 class TestNonReconnectingLDAPBackend(TestCase):
@@ -42,5 +42,5 @@ class TestNonReconnectingLDAPBackend(TestCase):
     def test_non_reconnecting_backend(self):
         backend = self.TestBackend()
         ldap_module = backend.ldap
-        self.assertFalse(isinstance(ldap_module, ReconnectingLDAP))
-        self.assertIs(ldap_module.SERVER_DOWN, ldap.SERVER_DOWN)
+        assert not isinstance(ldap_module, ReconnectingLDAP)
+        assert ldap_module.SERVER_DOWN is ldap.SERVER_DOWN

--- a/baya/tests/test_base.py
+++ b/baya/tests/test_base.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import django
 from django_auth_ldap import backend

--- a/baya/tests/test_dynamic_roles.py
+++ b/baya/tests/test_dynamic_roles.py
@@ -1,5 +1,5 @@
-from mock import MagicMock
-from mock import patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from unittest import TestCase
 

--- a/baya/tests/test_dynamic_roles.py
+++ b/baya/tests/test_dynamic_roles.py
@@ -26,21 +26,21 @@ class TestDjangoRequestGroupFormatter(TestCase):
     def test_returns_set(self):
         """The formatter should return a set of groups."""
         roles = self.formatter(self.build_mock_request('mygroup'))
-        self.assertEqual(type(roles), set)
-        self.assertEqual(len(roles), 1)
-        self.assertEqual(roles.pop(), "mygroup_admin")
+        assert type(roles) == set
+        assert len(roles) == 1
+        assert roles.pop() == "mygroup_admin"
 
     def test_query_param(self):
         request = self.build_mock_request('mygroup')
         roles = self.formatter(request)
-        self.assertEqual(roles, {'mygroup_admin'})
+        assert roles == {'mygroup_admin'}
 
     def test_reverse_kwarg(self):
         request = self.build_mock_request('mygroup')
         request.GET = {}
         request.resolver_match.kwargs = {'group': 'mygroup'}
         roles = self.formatter(request)
-        self.assertEqual(roles, {'mygroup_admin'})
+        assert roles == {'mygroup_admin'}
 
     def test_query_param_collision(self):
         """The URL kwarg should take precedence over the query parameter."""
@@ -48,14 +48,14 @@ class TestDjangoRequestGroupFormatter(TestCase):
         request.resolver_match.kwargs = {'group': 'kwarg_group'}
         with patch('baya.dynamic_roles.logger') as mock_logger:
             roles = self.formatter(request)
-            self.assertEqual(mock_logger.warning.call_count, 1)
-        self.assertEqual(roles, {'kwarg_group_admin'})
+            assert mock_logger.warning.call_count == 1
+        assert roles == {'kwarg_group_admin'}
 
     def test_str(self):
         st = str(self.formatter)
-        self.assertIn("%s_admin", st)
-        self.assertIn("group", st)
+        assert "%s_admin" in st
+        assert "group" in st
 
     def test_repr(self):
         re = repr(self.formatter)
-        self.assertIn(self.formatter.__class__.__name__, re)
+        assert self.formatter.__class__.__name__ in re

--- a/baya/tests/test_mock_ldap_helpers.py
+++ b/baya/tests/test_mock_ldap_helpers.py
@@ -12,28 +12,25 @@ class TestPerson(TestCase):
     def test_attrs(self):
         name = "bigfoot"
         person_attrs = person(name)
-        self.assertEqual(person_attrs[0],
-                         "cn=%s,ou=people,%s" % (name, DEFAULT_DC))
-        self.assertEqual(person_attrs[1]['uid'], [name])
-        self.assertEqual(person_attrs[1]['cn'], [name])
-        self.assertEqual(person_attrs[1]['sn'], [name])
-        self.assertEqual(person_attrs[1]['mail'], ["%s@test" % name])
+        assert person_attrs[0] == "cn=%s,ou=people,%s" % (name, DEFAULT_DC)
+        assert person_attrs[1]['uid'] == [name]
+        assert person_attrs[1]['cn'] == [name]
+        assert person_attrs[1]['sn'] == [name]
+        assert person_attrs[1]['mail'] == ["%s@test" % name]
 
     def test_password(self):
         name = "yeti"
         person_attrs = person(name)
-        self.assertEqual(person_attrs[1]['userPassword'], ['password'])
+        assert person_attrs[1]['userPassword'] == ['password']
         person_attrs = person(name, password='snowstorm')
-        self.assertEqual(person_attrs[1]['userPassword'], ['snowstorm'])
+        assert person_attrs[1]['userPassword'] == ['snowstorm']
 
     def test_email(self):
         name = "sasquatch"
         dc = "dc=test,dc=example,dc=com"
         person_attrs = person(name, dc=dc)
-        self.assertEqual(person_attrs[0],
-                         "cn=%s,ou=people,%s" % (name, dc))
-        self.assertEqual(person_attrs[1]['mail'],
-                         ["%s@test.example.com" % name])
+        assert person_attrs[0] == "cn=%s,ou=people,%s" % (name, dc)
+        assert person_attrs[1]['mail'] == ["%s@test.example.com" % name]
 
 
 class TestGroup(TestCase):
@@ -41,7 +38,7 @@ class TestGroup(TestCase):
         member = person('bigfoot')
         name = "north-american-great-apes"
         group_attrs = group(name, member)
-        self.assertEqual(group_attrs[1]['cn'], [name])
+        assert group_attrs[1]['cn'] == [name]
 
 
 class TestMockLdapDirectory(TestCase):
@@ -60,68 +57,65 @@ class TestMockLdapDirectory(TestCase):
             ],
             ldap_dc="",
         )
-        self.assertEqual(len(directory), 12)
-        self.assertIn(group_dn('child_1', ""), directory)
-        self.assertEqual(directory[group_dn('child_1', '')]['memberOf'],
-                         [group_dn('child_1_1', '')])
-        self.assertEqual(directory[group_dn('child_1', "")]['member'],
-                         [group_dn('the_parent', '')])
-        self.assertIn(group_dn('child_2', ""), directory)
-        self.assertEqual(
-            directory[group_dn('child_2', '')]['memberOf'],
-            [group_dn('child_2_1', ''), group_dn('child_2_2', '')])
-        self.assertEqual(directory[group_dn('child_2', "")]['member'],
-                         [group_dn('the_parent', '')])
-        self.assertIn(group_dn('child_1_1', ""), directory)
-        self.assertEqual(directory[group_dn('child_1_1', "")]['memberOf'], [])
-        self.assertEqual(directory[group_dn('child_1_1', "")]['member'],
-                         [group_dn('child_1', '')])
-        self.assertIn(group_dn('child_2_1', ""), directory)
-        self.assertEqual(directory[group_dn('child_2_1', "")]['memberOf'], [])
-        self.assertEqual(directory[group_dn('child_2_1', "")]['member'],
-                         [group_dn('child_2', '')])
-        self.assertIn(group_dn('child_2_2', ""), directory)
-        self.assertEqual(directory[group_dn('child_2_2', "")]['memberOf'], [])
-        self.assertEqual(directory[group_dn('child_2_2', "")]['member'],
-                         [group_dn('child_2', '')])
+        assert len(directory) == 12
+        assert group_dn('child_1', "") in directory
+        assert (directory[group_dn('child_1', '')]['memberOf'] ==
+                [group_dn('child_1_1', '')])
+        assert (directory[group_dn('child_1', "")]['member'] ==
+                [group_dn('the_parent', '')])
+        assert group_dn('child_2', "") in directory
+        assert (directory[group_dn('child_2', '')]['memberOf'] ==
+                [group_dn('child_2_1', ''), group_dn('child_2_2', '')])
+        assert (directory[group_dn('child_2', "")]['member'] ==
+                [group_dn('the_parent', '')])
+        assert group_dn('child_1_1', "") in directory
+        assert directory[group_dn('child_1_1', "")]['memberOf'] == []
+        assert (directory[group_dn('child_1_1', "")]['member'] ==
+                [group_dn('child_1', '')])
+        assert group_dn('child_2_1', "") in directory
+        assert directory[group_dn('child_2_1', "")]['memberOf'] == []
+        assert (directory[group_dn('child_2_1', "")]['member'] ==
+                [group_dn('child_2', '')])
+        assert group_dn('child_2_2', "") in directory
+        assert directory[group_dn('child_2_2', "")]['memberOf'] == []
+        assert (directory[group_dn('child_2_2', "")]['member'] ==
+                [group_dn('child_2', '')])
 
     def test_no_args(self):
         directory = mock_ldap_directory()
-        self.assertEqual(len(directory), 5)
-        self.assertSetEqual(
-            set(directory.keys()),
-            {
-                'ou=Access,dc=example,dc=com',
-                'dc=example,dc=com',
-                'ou=Service-Accounts,dc=example,dc=com',
-                'cn=auth,ou=people,dc=example,dc=com',
-                'ou=People,dc=example,dc=com'
-            })
+        assert len(directory) == 5
+        assert (set(directory.keys()) == {
+            'ou=Access,dc=example,dc=com',
+            'dc=example,dc=com',
+            'ou=Service-Accounts,dc=example,dc=com',
+            'cn=auth,ou=people,dc=example,dc=com',
+            'ou=People,dc=example,dc=com'
+        })
 
     def test_bind_user(self):
         directory = mock_ldap_directory(ldap_dc="")
         dn = person_dn('auth', "")
-        self.assertIn(dn, directory)
-        self.assertEqual(directory[dn]['userPassword'], ['password'])
+        assert dn in directory
+        assert directory[dn]['userPassword'] == ['password']
 
     def test_bind_password(self):
         directory = mock_ldap_directory(
             bind_user='ned', default_password='mancy', ldap_dc="")
         dn = person_dn('ned', "")
-        self.assertEqual(directory[dn]['userPassword'], ['password'])
+        assert directory[dn]['userPassword'] == ['password']
         directory = mock_ldap_directory(
             bind_user='ned', bind_password='flanders',
             default_password='mancy', ldap_dc="")
-        self.assertEqual(directory[dn]['userPassword'], ['flanders'])
+        assert directory[dn]['userPassword'] == ['flanders']
 
     def test_default_password(self):
         dn = person_dn('somebody', "")
         directory = mock_ldap_directory(
             ldap_dc="",
             extra_users=[('somebody', 'agroup')])
-        self.assertEqual(directory[dn]['userPassword'], ['password'])
+        assert directory[dn]['userPassword'] == ['password']
         directory = mock_ldap_directory(
             ldap_dc="",
             extra_users=[('somebody', 'agroup')],
             default_password='swordfish')
-        self.assertEqual(directory[dn]['userPassword'], ['swordfish'])
+        assert directory[dn]['userPassword'] == ['swordfish']

--- a/baya/tests/test_nodes.py
+++ b/baya/tests/test_nodes.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 from operator import and_
 from operator import or_

--- a/baya/tests/test_nodes.py
+++ b/baya/tests/test_nodes.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 from operator import and_
 from operator import or_
 from operator import xor
+import pytest
 from unittest import TestCase
 
 from ..membership import AndNode
@@ -15,30 +16,34 @@ class TestNodes(TestCase):
         a = g('A')
         b = g('B')
         c = g('C')
-        self.assertNotEqual(a, b)
-        self.assertEqual(a & b, a & b)
-        self.assertNotEqual(a & b, a | b)
-        self.assertEqual((a & b) | c, (a & b | c))
-        self.assertNotEqual(a & b, a | b)
-        self.assertNotEqual(a & b, a & b & c)
+        assert not a == b
+        assert a & b == a & b
+        assert not (a & b == a | b)
+        assert (a & b) | c == (a & b | c)
+        assert not (a & b == a | b)
+        assert not (a & b == a & b & c)
 
     def test_or_raises(self):
         """The or keyword is going to screw people up."""
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             g('A') or g('B')
 
     def test_and_raises(self):
         """The and keyword is going to screw people up."""
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             g('A') and g('B')
 
     def test_coercion(self):
         """Throw a TypeError when trying to combine nodes with non-nodes."""
         for op in [and_, or_, xor]:
-            self.assertRaises(TypeError, op, g('A'), 'b')
-            self.assertRaises(TypeError, op, 'b', g('A'))
-            self.assertRaises(TypeError, op, g('A'), 1234)
-            self.assertRaises(TypeError, op, 1234, g('A'))
+            with pytest.raises(TypeError):
+                op(g('A'), 'b')
+            with pytest.raises(TypeError):
+                op('b', g('A'))
+            with pytest.raises(TypeError):
+                op(g('A'), 1234)
+            with pytest.raises(TypeError):
+                op(1234, g('A'))
 
 
 class TestDynamicRolesNode(TestCase):
@@ -47,7 +52,7 @@ class TestDynamicRolesNode(TestCase):
         node = dg(roles_callable1)
         kwargs = {'a': 123}
         node.get_roles_set(**kwargs)
-        self.assertTrue(roles_callable1.called_with(**kwargs))
+        assert roles_callable1.called_with(**kwargs)
 
     def test_get_roles_set_multiple_callables(self):
         roles_callable1 = Mock(return_value=set())
@@ -55,35 +60,35 @@ class TestDynamicRolesNode(TestCase):
         node = dg(roles_callable1, roles_callable2)
         kwargs = {'b': 123}
         node.get_roles_set(**kwargs)
-        self.assertTrue(roles_callable1.called_with(**kwargs))
-        self.assertTrue(roles_callable2.called_with(**kwargs))
+        assert roles_callable1.called_with(**kwargs)
+        assert roles_callable2.called_with(**kwargs)
 
     def test_get_roles_set_or(self):
         c1 = lambda: {True}
         c2 = lambda: {True}
         c3 = lambda: {False}
         node = dg(c1, c2, c3)
-        self.assertEqual(node.get_roles_set(), {True, False})
+        assert node.get_roles_set() == {True, False}
 
     def test_invalid_callable_return(self):
         c1 = lambda x: x
         node = dg(c1)
-        self.assertRaises(RuntimeError, node.get_roles_set, x='abc')
+        with pytest.raises(RuntimeError):
+            node.get_roles_set(x='abc')
 
     def test_combine_roles(self):
         """Combining roles into a simpler node when AND-ing."""
         role1 = dg(lambda x: x)
         role2 = dg(lambda y: y)
         combined = role1 & role2
-        self.assertTrue(isinstance(combined, dg))
-        self.assertLess(role1._roles_set, combined._roles_set)
-        self.assertLess(role2._roles_set, combined._roles_set)
-        self.assertEqual(role1._roles_set | role2._roles_set,
-                         combined._roles_set)
+        assert isinstance(combined, dg)
+        assert role1._roles_set < combined._roles_set
+        assert role2._roles_set < combined._roles_set
+        assert role1._roles_set | role2._roles_set == combined._roles_set
 
     def test_combine_regular_role(self):
         """Combining with a regular node should just give an AndNode."""
         role1 = g('abc')
         role2 = dg(lambda y: y)
         combined = role1 & role2
-        self.assertTrue(isinstance(combined, AndNode))
+        assert isinstance(combined, AndNode)

--- a/baya/tests/test_permissions.py
+++ b/baya/tests/test_permissions.py
@@ -1,9 +1,8 @@
 import functools
-from mock import patch
-from mock import sentinel
+from unittest.mock import patch
+from unittest.mock import sentinel
 from types import FunctionType
 
-import six
 import django
 from django.conf import settings
 if django.VERSION[:2] < (4, 0):
@@ -159,8 +158,8 @@ class TestGate(LDAPGroupAuthTestBase):
         custom_login = "/testlogin/"
         g3 = Gate(login_url=custom_login)
         self.assertEqual(g3.login_url, custom_login)
-        self.assertEqual(six.text_type((g3 + g2).login_url),
-                         six.text_type(custom_login))
+        self.assertEqual(str((g3 + g2).login_url),
+                         str(custom_login))
         self.assertEqual((g2 + g3).login_url, custom_login)
         with override_settings(BAYA_LOGIN_URL="/testlogin/"):
             g4 = Gate()

--- a/baya/tests/test_templatetags.py
+++ b/baya/tests/test_templatetags.py
@@ -1,9 +1,11 @@
+import pytest
 from django.template import Context
 from django.template import Template
 from .test_base import LDAPGroupAuthTestBase
 from django.contrib.auth.models import AnonymousUser
 
 
+@pytest.mark.django_db
 class CanUserPerformActionTagTest(LDAPGroupAuthTestBase):
 
     BASIC_TEMPLATE = Template(
@@ -22,7 +24,7 @@ class CanUserPerformActionTagTest(LDAPGroupAuthTestBase):
             'user': AnonymousUser(),
         })
         rendered = self.BASIC_TEMPLATE.render(context)
-        self.assertIn('False', rendered)
+        assert 'False' in rendered
 
     def test_has_permission_false(self):
         context = Context({
@@ -30,7 +32,7 @@ class CanUserPerformActionTagTest(LDAPGroupAuthTestBase):
             'user': self.login('has_nothing'),
         })
         rendered = self.BASIC_TEMPLATE.render(context)
-        self.assertIn('False', rendered)
+        assert 'False' == rendered
 
     def test_has_permission_true(self):
         context = Context({
@@ -38,4 +40,4 @@ class CanUserPerformActionTagTest(LDAPGroupAuthTestBase):
             'user': self.login('has_all'),
         })
         rendered = self.BASIC_TEMPLATE.render(context)
-        self.assertIn('True', rendered)
+        assert 'True' in rendered

--- a/baya/tests/test_visitors.py
+++ b/baya/tests/test_visitors.py
@@ -1,4 +1,4 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
 from unittest import TestCase
 
 from ..dynamic_roles import DjangoRequestGroupFormatter

--- a/baya/utils.py
+++ b/baya/utils.py
@@ -1,4 +1,3 @@
-import six
 from ldap.dn import str2dn
 
 from .membership import RolesNode as g
@@ -22,7 +21,7 @@ def user_in_group(user, group, **kwargs):
     user_groups = set()
     if hasattr(user, 'ldap_user'):
         user_groups = group_names(user.ldap_user.group_dns)
-    if isinstance(group, six.string_types):
+    if isinstance(group, str):
         group = g(group)
     return PermissionChecker(user_groups).visit(group, **kwargs)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 coverage==5.1
 django-nose==1.4.6
 funcparserlib==0.3.6
-mock==1.0.1
 mockldap==0.2.6
 nose==1.3.7
 pycodestyle==2.9.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,11 @@
-coverage==5.1
-django-nose==1.4.6
+coverage
 funcparserlib==0.3.6
 mockldap==0.2.6
-nose==1.3.7
 pycodestyle==2.9.1
 pyflakes==2.5.0
 flake8==5.0.4
+
+pytest==7.0.1
+py==1.11.0
+pytest-cov==3.0.0
+pytest-django==4.5.2

--- a/requirements-setup.txt
+++ b/requirements-setup.txt
@@ -1,6 +1,6 @@
 # Requirements needed for the setup make target and the test target
 # outside of the individual tox environments.
-
+setuptools<58.0
 pluggy==1.0.0
 py==1.11.0
 tox==3.27.1

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,6 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 install_command = pip install {opts} {packages}
 downloadcache = {toxworkdir}/_download/
-envlist = {py37}-django{3.1,3.2},{py38,py39,py310,py311}-django{3.1,3.2,4.0,4.1}
+envlist = {py37}-django{3.1,3.2},{py38,py39,py310,py311}-django{3.1,3.2,4.0,4.1},p312-django{3.2,4.0,4.1}
 indexserver =
     default = https://pypi.python.org/simple
 
@@ -9,9 +9,10 @@ indexserver =
 [testenv]
 setuptools_version = setuptools<58.0
 usedevelop = True
+setenv =
+  DJANGO_SETTINGS_MODULE=baya.tests.settings
 commands =
-  coverage run --omit="*tests*" --source=baya --branch \
-    ./baya/tests/manage.py test {posargs:baya}
+  py.test {posargs:baya}
 deps =
   -r{toxinidir}/requirements-dev.txt
   django3.1: Django>=3.1,<3.2
@@ -25,11 +26,18 @@ whitelist_externals = flake8
 commands =
   flake8 -v baya/
 
+[testenv:py311-django3.2]
+commands =
+  rm -f .coverage
+  py.test --cov=baya {posargs:baya}
 
 [flake8]
 max-line-length = 99
 ignore = E731,E402,W504
 
+[pytest]
+DJANGO_SETTINGS_MODULE = baya.tests.settings
+python_files = tests.py test_*.py *_tests.py
 
 [gh-actions]
 python =
@@ -38,3 +46,4 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312


### PR DESCRIPTION
for compatibly to python 3.11, we either needed to remove mock in favor of the unittest.mock, or update current mock version. 
I decided to remove it since python 2.7 is deprecated and unittest.mock is native to python 3+

I also removed references to `six` 